### PR TITLE
Add both toolchains to .buckconfig repositories

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,8 +1,8 @@
 [repositories]
 root = .
 prelude = prelude
-#toolchains = toolchains
 toolchains = ghcHEAD-toolchains
+toolchains_unused = toolchains
 none = none
 
 [repository_aliases]


### PR DESCRIPTION
This hides the targets from the root so it cannot be used unintentionally.
i.e. without this change, //toolchains appears in a query of //...

Prevents a repeat of https://github.com/MercuryTechnologies/buck2-ghc-build/pull/16