### PR TITLE
RTS build for linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,6 @@
             pkgs.buck2-source
             pkgs.nix
             pkgs.jq
-            # REMOVE LATER
-            pkgs.alex
-            pkgs.libffi.dev
           ];
           # GHC in invokes Nix cc, cc-wrapper invokes mktemp from $PATH. Also GHC invokes otool and
           # install_name_tool from $PATH on Darwin.

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
             pkgs.jq
             # REMOVE LATER
             pkgs.alex
+            pkgs.libffi.dev
           ];
           # GHC in invokes Nix cc, cc-wrapper invokes mktemp from $PATH. Also GHC invokes otool and
           # install_name_tool from $PATH on Darwin.

--- a/ghc-build/BUCK
+++ b/ghc-build/BUCK
@@ -351,8 +351,7 @@ haskell_library(
     ],
     visibility = ["PUBLIC"],
     deps = [
-        # until we fix linux build, this is commented out.
-        #":rts",
+        ":rts",
     ],
 )
 

--- a/ghc-build/BUCK
+++ b/ghc-build/BUCK
@@ -200,7 +200,7 @@ $(hc) -c $(location :AutoApply.cmm) -o ../out/AutoApply.o -fPIC -I./ghc/rts
 )
 
 includeFlags = [
-    "-I/nix/store/m2ci1q4vy264dp2j7fj0rd847k2gs4y4-libffi-3.4.4-dev/include",
+    "-I$(location @toolchains//:libffi)/include",
     "-I/nix/store/ylzhyqf98cfpib8abcq8ilnb4i8pk5c5-epoll-shim-0.0.20230411/include/libepoll-shim",
     "-I",
     "-I./ghc-buid",
@@ -226,7 +226,6 @@ cxx_library(
     compiler_flags = select({
         "@prelude//os:linux": [
             # for now
-            #"--target=x86_64-unknown-linux",
             "-fPIC",
             "-Dlinux_HOST_OS",
             "-DUSE_MINIINTERPRETER",
@@ -247,13 +246,9 @@ cxx_library(
             "-DRtsWay=\"rts_dyn\"",
             "-DGhcUnregisterised=\"NO\"",
             "-DTablesNextToCode=\"dummy\"",
-            "-DOBJFORMAT_ELF",
-            "-I/nix/store/hp2gy863515lcv0gv8773yj2364ipfiz-libffi-3.4.4-dev/include",
-            "-Wl,-u,StgRun",
           ] + includeFlags,
         "@prelude//os:macos": [
             # for now
-            "--target=arm64-apple-darwin",
             "-Ddarwin_HOST_OS",
             "-DUSE_MINIINTERPRETER",
             "-DBuildArch=\"aarch64\"",

--- a/ghc-build/BUCK
+++ b/ghc-build/BUCK
@@ -173,7 +173,7 @@ genrule(
       srcs = [src] + deps,
       out = obj,
       cmd = '''
-$(hc) -c {} -o ../out/{} -Ighc-build -Ighc-build/include -Ighc-build/ghc/rts -Ighc-build/ghc/rts/include
+$(hc) -fPIC -dynamic -c {} -o ../out/{} -Ighc-build -Ighc-build/include -Ighc-build/ghc/rts -Ighc-build/ghc/rts/include
 '''.format(src,obj) ,
   )
   for obj, src, deps in [
@@ -195,9 +195,20 @@ haskell_genrule(
     srcs = [":AutoApply.cmm", "ghc/rts/AutoApply.h"],
     out = "AutoApply.o",
     cmd = '''
-$(hc) -c $(location :AutoApply.cmm) -o ../out/AutoApply.o -I./ghc/rts
+$(hc) -c $(location :AutoApply.cmm) -o ../out/AutoApply.o -fPIC -I./ghc/rts
 '''
 )
+
+includeFlags = [
+    "-I/nix/store/m2ci1q4vy264dp2j7fj0rd847k2gs4y4-libffi-3.4.4-dev/include",
+    "-I/nix/store/ylzhyqf98cfpib8abcq8ilnb4i8pk5c5-epoll-shim-0.0.20230411/include/libepoll-shim",
+    "-I",
+    "-I./ghc-buid",
+    "-Ighc-build",
+    "-Ighc-build/include",
+    "-Ighc-build/ghc/rts",
+    "-Ighc-build/ghc/rts/include",
+]
 
 cxx_library(
     name = "rts",
@@ -208,37 +219,59 @@ cxx_library(
         "ghc/rts/adjustor/NativeAmd64Mingw.c",
         "ghc/rts/adjustor/NativeAmd64.c",
         "ghc/rts/adjustor/Nativei386.c",
+        "ghc/rts/linker/MachO.*",
+        "ghc/rts/linker/macho/**",
     ]),
     headers = glob(["ghc/rts/**/*.h"], exclude = ["ghc/rts/win32/**/*", "ghc/rts/wasm/**/*"]),
-    compiler_flags = [
-        # for now
-        "--target=arm64-apple-darwin",
-        "-Ddarwin_HOST_OS",
-        "-DBuildArch=\"aarch64\"",
-        "-DBuildOS=\"dummy\"",
-        "-DBuildPlatform=\"dummy\"",
-        "-DBuildVendor=\"dummy\"",
-        "-DHostArch=\"aarch64\"",
-        "-DHostOS=\"dummy\"",
-        "-DHostPlatform=\"dummy\"",
-        "-DHostVendor=\"dummy\"",
-        "-DTargetArch=\"aarch64\"",
-        "-DTargetOS=\"dummy\"",
-        "-DTargetPlatform=\"dummy\"",
-        "-DTargetVendor=\"dummy\"",
-        "-DProjectVersion=\"000\"",
-        "-DRtsWay=\"rts_dyn\"",
-        "-DGhcUnregisterised=\"NO\"",
-        "-DTablesNextToCode=\"dummy\"",
-        "-I/nix/store/m2ci1q4vy264dp2j7fj0rd847k2gs4y4-libffi-3.4.4-dev/include",
-        "-I/nix/store/ylzhyqf98cfpib8abcq8ilnb4i8pk5c5-epoll-shim-0.0.20230411/include/libepoll-shim",
-        "-I",
-        "-I./ghc-buid",
-        "-Ighc-build",
-        "-Ighc-build/include",
-        "-Ighc-build/ghc/rts",
-        "-Ighc-build/ghc/rts/include",
-    ],
+    compiler_flags = select({
+        "@prelude//os:linux": [
+            # for now
+            #"--target=x86_64-unknown-linux",
+            "-fPIC",
+            "-Dlinux_HOST_OS",
+            "-DHAVE_PTHREAD_SETNAME_NP",
+            "-DBuildArch=\"ArchX86_64\"",
+            "-DBuildOS=\"dummy\"",
+            "-DBuildPlatform=\"dummy\"",
+            "-DBuildVendor=\"dummy\"",
+            "-DHostArch=\"ArchX86_64\"",
+            "-DHostOS=\"dummy\"",
+            "-DHostPlatform=\"dummy\"",
+            "-DHostVendor=\"dummy\"",
+            "-DTargetArch=\"ArchX86_64\"",
+            "-DTargetOS=\"dummy\"",
+            "-DTargetPlatform=\"dummy\"",
+            "-DTargetVendor=\"dummy\"",
+            "-DProjectVersion=\"000\"",
+            "-DRtsWay=\"rts_dyn\"",
+            "-DGhcUnregisterised=\"NO\"",
+            "-DTablesNextToCode=\"dummy\"",
+            "-DOBJFORMAT_ELF",
+            "-I/nix/store/hp2gy863515lcv0gv8773yj2364ipfiz-libffi-3.4.4-dev/include",
+            "-Wl,-u,StgRun",
+          ] + includeFlags,
+        "@prelude//os:macos": [
+            # for now
+            "--target=arm64-apple-darwin",
+            "-Ddarwin_HOST_OS",
+            "-DBuildArch=\"aarch64\"",
+            "-DBuildOS=\"dummy\"",
+            "-DBuildPlatform=\"dummy\"",
+            "-DBuildVendor=\"dummy\"",
+            "-DHostArch=\"aarch64\"",
+            "-DHostOS=\"dummy\"",
+            "-DHostPlatform=\"dummy\"",
+            "-DHostVendor=\"dummy\"",
+            "-DTargetArch=\"aarch64\"",
+            "-DTargetOS=\"dummy\"",
+            "-DTargetPlatform=\"dummy\"",
+            "-DTargetVendor=\"dummy\"",
+            "-DProjectVersion=\"000\"",
+            "-DRtsWay=\"rts_dyn\"",
+            "-DGhcUnregisterised=\"NO\"",
+            "-DTablesNextToCode=\"dummy\"",
+          ] + includeFlags,
+    }),
     link_style = "shared",
     linker_flags = [
         "$(location :Apply.o)",
@@ -252,9 +285,10 @@ cxx_library(
         "$(location :StgStdThunks.o)",
         "$(location :Updates.o)",
         "$(location :Exception.o)",
-        "-undefined",
-        "dynamic_lookup",
-    ],
+    ] + select({
+        "@prelude//os:linux": ["-Wl,--unresolved-symbols=ignore-all", "-Wl,-u,StgRun"],
+        "@prelude//os:macos": ["-undefined", "dynamic_lookup"],
+    }),
     deps = [
         ":Apply.o",
         ":AutoApply.o",

--- a/ghc-build/BUCK
+++ b/ghc-build/BUCK
@@ -229,6 +229,7 @@ cxx_library(
             #"--target=x86_64-unknown-linux",
             "-fPIC",
             "-Dlinux_HOST_OS",
+            "-DUSE_MINIINTERPRETER",
             "-DHAVE_PTHREAD_SETNAME_NP",
             "-DBuildArch=\"ArchX86_64\"",
             "-DBuildOS=\"dummy\"",
@@ -254,6 +255,7 @@ cxx_library(
             # for now
             "--target=arm64-apple-darwin",
             "-Ddarwin_HOST_OS",
+            "-DUSE_MINIINTERPRETER",
             "-DBuildArch=\"aarch64\"",
             "-DBuildOS=\"dummy\"",
             "-DBuildPlatform=\"dummy\"",

--- a/ghc-build/ghcautoconf.h
+++ b/ghc-build/ghcautoconf.h
@@ -287,8 +287,10 @@
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
 
+#if darwin_HOST_OS
 /* Define to 1 if Apple-style dead-stripping is supported. */
 #define HAVE_SUBSECTIONS_VIA_SYMBOLS 1
+#endif
 
 /* Define to 1 if you have the `sysconf' function. */
 #define HAVE_SYSCONF 1

--- a/ghc-build/ghcplatform.h
+++ b/ghc-build/ghcplatform.h
@@ -1,6 +1,7 @@
 #if !defined(__GHCPLATFORM_H__)
 #define __GHCPLATFORM_H__
 
+#ifdef darwin_HOST_OS
 #define BuildPlatform_TYPE  aarch64_apple_darwin
 #define HostPlatform_TYPE   aarch64_apple_darwin
 
@@ -21,5 +22,30 @@
 #define apple_HOST_VENDOR  1
 #define BUILD_VENDOR  "apple"
 #define HOST_VENDOR  "apple"
+
+#else
+
+#define BuildPlatform_TYPE  x86_64_unknown_linux
+#define HostPlatform_TYPE   x86_64_unknown_linux
+
+#define x86_64_unknown_linux_BUILD  1
+#define x86_64_unknown_linux_HOST  1
+
+#define x86_64_BUILD_ARCH  1
+#define x86_64_HOST_ARCH  1
+#define BUILD_ARCH  "x86_64"
+#define HOST_ARCH  "x86_64"
+
+#define linux_BUILD_OS  1
+#define linux_HOST_OS  1
+#define BUILD_OS  "linux"
+#define HOST_OS  "linux"
+
+#define unknown_BUILD_VENDOR  1
+#define unknown_HOST_VENDOR  1
+#define BUILD_VENDOR  "unknown"
+#define HOST_VENDOR  "unknown"
+
+#endif
 
 #endif /* __GHCPLATFORM_H__ */

--- a/ghcHEAD-toolchains/BUCK
+++ b/ghcHEAD-toolchains/BUCK
@@ -89,3 +89,10 @@ nix.rules.flake(
 )
 
 ################################################################################
+
+nix.rules.flake(
+    name = "libffi",
+    flake = "nix",
+    suffix = "dev",
+    visibility = ["PUBLIC"],
+)

--- a/ghcHEAD-toolchains/nix/flake.nix
+++ b/ghcHEAD-toolchains/nix/flake.nix
@@ -104,6 +104,7 @@
           hsc2hs = pkgs.haskellPackages.hsc2hs;
 
           python = pkgs.python3;
+          libffi = pkgs.libffi.dev;
         };
       });
 }


### PR DESCRIPTION
conditional build for linux and macOS.
@toolchains//:libffi is provided.
now ghc-prim -> rts dependency is enabled.
